### PR TITLE
Fix remaining Buildifier warnings

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -22,7 +22,7 @@ package(
 license(
     name = "license",
     license_kinds = [
-        "@rules_license//licenses/spdx:Apache-2.0"
+        "@rules_license//licenses/spdx:Apache-2.0",
     ],
     license_text = "LICENSE",
 )
@@ -38,4 +38,3 @@ exports_files(
     ]),
     visibility = ["//visibility:public"],
 )
-

--- a/examples/src/BUILD
+++ b/examples/src/BUILD
@@ -1,7 +1,8 @@
 # Examples of applications and interactions with licenses
 
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("@rules_license//examples/vendor/constant_gen:defs.bzl", "constant_gen")
-load("@rules_license//rules:compliance.bzl", "check_license", "licenses_used")
+load("@rules_license//rules:compliance.bzl", "licenses_used")
 load("@rules_license//rules:license_policy_check.bzl", "license_policy_check")
 load("@rules_license//tools:test_helpers.bzl", "golden_test")
 

--- a/examples/vendor/acme/BUILD
+++ b/examples/vendor/acme/BUILD
@@ -1,5 +1,6 @@
 # A package with a commercial license.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_license//rules:license.bzl", "license")
 
 package(

--- a/examples/vendor/constant_gen/BUILD
+++ b/examples/vendor/constant_gen/BUILD
@@ -1,9 +1,10 @@
 # An example of a code generator with a distinct license for the generated code.
 
-load(":defs.bzl", "constant_gen")
 load("@rules_license//rules:compliance.bzl", "licenses_used")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_license//tools:test_helpers.bzl", "golden_test")
+load("@rules_python//python:defs.bzl", "py_binary")
+load(":defs.bzl", "constant_gen")
 
 package(
     default_applicable_licenses = [":license"],

--- a/examples/vendor/constant_gen/defs.bzl
+++ b/examples/vendor/constant_gen/defs.bzl
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 def _constant_gen_impl(ctx):
     # Turn text into a C++ constant.
     outputs = [ctx.outputs.src_out]
@@ -52,7 +54,7 @@ def constant_gen(name, text, var):
     )
 
     # And turn it into a library we can link against
-    native.cc_library(
+    cc_library(
         name = name,
         srcs = [name + "_src_"],
         applicable_licenses = ["@rules_license//examples/vendor/constant_gen:license_for_emitted_code"],

--- a/examples/vendor/libhhgttg/BUILD
+++ b/examples/vendor/libhhgttg/BUILD
@@ -1,6 +1,7 @@
 # A package with all code under a single license. This is the most common case
 # we expect to see.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_license//rules:license.bzl", "license")
 
 # Using a package wide default ensure that all targets are associated with the

--- a/licenses/spdx/BUILD
+++ b/licenses/spdx/BUILD
@@ -59,7 +59,6 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-
 license_kind(
     name = "0BSD",
     conditions = [],

--- a/rules/compliance.bzl
+++ b/rules/compliance.bzl
@@ -15,13 +15,13 @@
 """Proof of concept. License compliance checking."""
 
 load(
-    "@rules_license//rules:providers.bzl",
-    "LicensesInfo",
-)
-load(
     "@rules_license//rules:gather_licenses_info.bzl",
     "gather_licenses_info",
     "write_licenses_info",
+)
+load(
+    "@rules_license//rules:providers.bzl",
+    "LicensesInfo",
 )
 
 # Debugging verbosity
@@ -75,11 +75,11 @@ def _check_license_impl(ctx):
 _check_license = rule(
     implementation = _check_license_impl,
     attrs = {
+        "check_conditions": attr.bool(default = True, mandatory = False),
+        "copyright_notices": attr.output(mandatory = False),
         "deps": attr.label_list(
             aspects = [gather_licenses_info],
         ),
-        "check_conditions": attr.bool(default = True, mandatory = False),
-        "copyright_notices": attr.output(mandatory = False),
         "license_texts": attr.output(mandatory = False),
         "report": attr.output(mandatory = True),
         "_checker": attr.label(

--- a/rules/default_license.bzl
+++ b/rules/default_license.bzl
@@ -17,7 +17,6 @@
 load(
     "@rules_license//rules:providers.bzl",
     "LicenseInfo",
-    "LicenseKindInfo",
     "LicensesInfo",
 )
 
@@ -35,14 +34,14 @@ def _default_licenses_impl(ctx):
 _default_licenses = rule(
     implementation = _default_licenses_impl,
     attrs = {
+        "conditions": attr.string_list(
+            doc = "",
+        ),
         "deps": attr.label_list(
             mandatory = True,
             doc = "Licenses",
             providers = [LicenseInfo],
             cfg = "host",
-        ),
-        "conditions": attr.string_list(
-            doc = "",
         ),
     },
 )

--- a/rules/default_license.bzl
+++ b/rules/default_license.bzl
@@ -46,10 +46,10 @@ _default_licenses = rule(
     },
 )
 
-# buildifier: disable=unamed-macro
+# buildifier: disable=unnamed-macro
 def default_licenses(licenses, conditions = None):
     _default_licenses(
         name = "__default_licenses",
-        deps = ["%s_license" % l for l in licenses],
+        deps = ["%s_license" % license for license in licenses],
         conditions = conditions,
     )

--- a/rules/license.bzl
+++ b/rules/license.bzl
@@ -45,6 +45,9 @@ def _license_impl(ctx):
 _license = rule(
     implementation = _license_impl,
     attrs = {
+        "copyright_notice": attr.string(
+            doc = "Copyright notice.",
+        ),
         "license_kinds": attr.label_list(
             mandatory = True,
             doc = "License kind(s) of this license. If multiple license kinds are" +
@@ -53,9 +56,6 @@ _license = rule(
                   " of many, then only list one here.",
             providers = [LicenseKindInfo],
             cfg = "host",
-        ),
-        "copyright_notice": attr.string(
-            doc = "Copyright notice.",
         ),
         "license_text": attr.label(
             allow_single_file = True,

--- a/rules/license_kind.bzl
+++ b/rules/license_kind.bzl
@@ -37,14 +37,14 @@ def _license_kind_impl(ctx):
 _license_kind = rule(
     implementation = _license_kind_impl,
     attrs = {
+        "canonical_text": attr.label(
+            doc = "File containing the canonical text for this license. Must be UTF-8 encoded.",
+            allow_single_file = True,
+        ),
         "conditions": attr.string_list(
             doc = "Conditions to be met when using software under this license." +
                   "  Conditions are defined by the organization using this license.",
             mandatory = True,
-        ),
-        "canonical_text": attr.label(
-            doc = "File containing the canonical text for this license. Must be UTF-8 encoded.",
-            allow_single_file = True,
         ),
         "url": attr.string(doc = "URL pointing to canonical license definition"),
     },

--- a/rules/license_policy_check.bzl
+++ b/rules/license_policy_check.bzl
@@ -15,16 +15,16 @@
 """License compliance checking at analysis time."""
 
 load(
-    "@rules_license//rules:providers.bzl",
-    "LicensesInfo",
-)
-load(
     "@rules_license//rules:gather_licenses_info.bzl",
     "gather_licenses_info",
 )
 load(
     "@rules_license//rules:license_policy_provider.bzl",
     "LicensePolicyInfo",
+)
+load(
+    "@rules_license//rules:providers.bzl",
+    "LicensesInfo",
 )
 
 def _license_policy_check_impl(ctx):
@@ -46,16 +46,16 @@ _license_policy_check = rule(
     implementation = _license_policy_check_impl,
     doc = """Internal tmplementation method for license_policy_check().""",
     attrs = {
+        "policy": attr.label(
+            doc = """Policy definition.""",
+            mandatory = True,
+            providers = [LicensePolicyInfo],
+        ),
         "target": attr.label(
             doc = """Target to collect LicenseInfo for.""",
             aspects = [gather_licenses_info],
             mandatory = True,
             allow_single_file = True,
-        ),
-        "policy": attr.label(
-            doc = """Policy definition.""",
-            mandatory = True,
-            providers = [LicensePolicyInfo],
         ),
     },
 )

--- a/rules/license_policy_provider.bzl
+++ b/rules/license_policy_provider.bzl
@@ -17,8 +17,8 @@
 LicensePolicyInfo = provider(
     doc = """Declares a policy name and the license conditions allowable under it.""",
     fields = {
-        "name": "License Policy Name",
-        "label": "The full path to the license policy definition.",
         "conditions": "List of conditions to be met when using this software.",
+        "label": "The full path to the license policy definition.",
+        "name": "License Policy Name",
     },
 )

--- a/rules/providers.bzl
+++ b/rules/providers.bzl
@@ -17,9 +17,9 @@
 LicenseKindInfo = provider(
     doc = """Provides information about a license kind.""",
     fields = {
-        "name": "License Name",
-        "label": "The full path to the license kind definition.",
         "conditions": "List of conditions to be met when using this software.",
+        "label": "The full path to the license kind definition.",
+        "name": "License Name",
     },
 )
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,5 +1,7 @@
 """Test cases for license rules."""
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 load("@rules_license//rules:compliance.bzl", "check_license")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_license//rules:license_kind.bzl", "license_kind")

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -11,10 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""License declaration and compliance checking tools."""
 
 load("@rules_python//python:defs.bzl", "py_binary")
-
-"""License declaration and compliance checking tools."""
 
 package(
     default_applicable_licenses = ["//:license"],

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_python//python:defs.bzl", "py_binary")
+
 """License declaration and compliance checking tools."""
 
 package(


### PR DESCRIPTION
Running `buildifier --lint=warn --warnings=all -v -r .` in the `aiuto:linty` branch produced 25 Buildifier warnings. This change applies the changes needed to satisfy Buildifier. Running `buildifier --lint=warn --warnings=all -v -r .` now results in zero warnings.

`bazel build //tests/...` runs successfully 

